### PR TITLE
feature: add keyboard resizing for better accessibility

### DIFF
--- a/src/components/code-bubble/code-bubble.test.ts
+++ b/src/components/code-bubble/code-bubble.test.ts
@@ -392,6 +392,53 @@ describe('CodeBubble', () => {
     });
   });
 
+  describe('resize', () => {
+    it('should decrease maxWidth when ArrowLeft is pressed', async () => {
+      const codeBubble = await getCodeBubble();
+
+      const resizeHandle = codeBubble.shadowRoot?.querySelector<HTMLButtonElement>('.resize-handle');
+      const resizeContainer = codeBubble.shadowRoot?.querySelector<HTMLElement>('.resize-container');
+  
+      resizeContainer.style.maxWidth = '160px';
+      resizeHandle.focus();
+  
+      const event = new KeyboardEvent('keydown', { key: 'ArrowLeft' });
+      resizeHandle.dispatchEvent(event);
+  
+      expect(resizeContainer.style.maxWidth).to.equal('150px');
+    });
+  
+    it('should increase maxWidth when ArrowRight is pressed', async () => {
+      const codeBubble = await getCodeBubble();
+
+      const resizeHandle = codeBubble.shadowRoot?.querySelector<HTMLButtonElement>('.resize-handle');
+      const resizeContainer = codeBubble.shadowRoot?.querySelector<HTMLElement>('.resize-container');
+  
+      resizeContainer.style.maxWidth = '160px';
+      resizeHandle.focus();
+  
+      const event = new KeyboardEvent('keydown', { key: 'ArrowRight' });
+      resizeHandle.dispatchEvent(event);
+  
+      expect(resizeContainer.style.maxWidth).to.equal('170px');
+    });
+  
+    it('should not change maxWidth for other keys', async () => {
+      const codeBubble = await getCodeBubble();
+
+      const resizeHandle = codeBubble.shadowRoot?.querySelector<HTMLButtonElement>('.resize-handle');
+      const resizeContainer = codeBubble.shadowRoot?.querySelector<HTMLElement>('.resize-container');
+  
+      resizeContainer.style.maxWidth = '160px';
+      resizeHandle.focus();
+  
+      const event = new KeyboardEvent('keydown', { key: 'Enter' });
+      resizeHandle.dispatchEvent(event);
+  
+      expect(resizeContainer.style.maxWidth).to.equal('160px');
+    });  
+  });
+
   describe('preview', () => {
     it('should hide the preview', async () => {
       const codeBubble = await getCodeBubble();

--- a/src/components/code-bubble/code-bubble.ts
+++ b/src/components/code-bubble/code-bubble.ts
@@ -393,6 +393,27 @@ export default class CodeBubble extends LitElement {
     );
   }
 
+  private handleKeydown(e: KeyboardEvent) {
+    const resizeHandle = this.shadowRoot?.querySelector('.resize-handle');
+    if (e.target !== resizeHandle) {
+      return;
+    }
+
+    const resizeContainer = this.resizeContainer;
+    const startWidth = parseInt(getComputedStyle(resizeContainer).width, 10);
+
+    switch (e.key) {
+      case 'ArrowLeft':
+        resizeContainer.style.maxWidth = `${startWidth - 10}px`;
+        break;
+      case 'ArrowRight':
+        resizeContainer.style.maxWidth = `${startWidth + 10}px`;
+        break;
+      default:
+        break;
+    }
+  }
+
   @eventOptions({ passive: true })
   private handleDrag(e: TouchEvent) {
     const startX = e.changedTouches
@@ -451,6 +472,7 @@ export default class CodeBubble extends LitElement {
                 ${!this.hideResize && !this.componentConfig.resizeButton?.hide
                   ? html`<button
                       class="resize-handle"
+                      @keydown=${this.handleKeydown}
                       @mousedown=${this.handleDrag}
                       @touchstart=${this.handleDrag}
                     >


### PR DESCRIPTION
To address this [feature request](https://github.com/break-stuff/code-bubble/issues/20), I've added a keydown event listener, the callback function, and relevant tests.

![2025-02-07 14 50 38](https://github.com/user-attachments/assets/932f16a9-a975-4866-a814-225db0e7673b)

The user can now keyboard tab to focus on the resize handle, and use the arrow keys to update the size.
