### PR TITLE
Update focus behavior when showing code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.2
+
+- Shift focus to code when "Show Code" button is clicked
+
 ## 1.3.1
 
 - Added missing methods: setLanguage and updateConfig

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-bubble",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Reusable components for displaying code examples and providing links to a sandbox environment.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/components/code-bubble/code-bubble.ts
+++ b/src/components/code-bubble/code-bubble.ts
@@ -314,6 +314,10 @@ export default class CodeBubble extends LitElement {
   private handleShowSourceClick() {
     this.openShowCode = !this.openShowCode;
 
+    if(this.openShowCode) {
+      this.shadowRoot?.querySelector('details')?.focus();
+    }
+
     if (typeof this.config.hooks?.onShowCode === 'function') {
       this.config.hooks.onShowCode(this.openShowCode);
     }
@@ -489,6 +493,7 @@ export default class CodeBubble extends LitElement {
           id="code-bubble"
           class="code-bubble"
           part="code-bubble-code"
+          tabindex="-1"
           ?open=${this.openShowCode}
         >
           <!-- required to prevent the user-agent summery from displaying -->


### PR DESCRIPTION
When the show code buttonis clicked, the focus should now shif back to the code section